### PR TITLE
Fix deprecated method

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])


### PR DESCRIPTION
Fix warning `File.exists?` is deprecated in favor of `File.exist?`.
